### PR TITLE
Remove treasury allocation

### DIFF
--- a/contracts/TokenFactory.sol
+++ b/contracts/TokenFactory.sol
@@ -6,28 +6,23 @@ import "./interfaces/ITokenFactory.sol";
 
 /// @notice Token Factory used to deploy votes tokens
 contract TokenFactory is ITokenFactory, ERC165 {
-
     /// @dev Creates an ERC-20 votes token
     /// @param data The array of bytes used to create the token
     /// @return address The address of the created token
     function create(bytes[] calldata data) external override returns (address[] memory) {
         address[] memory createdContracts = new address[](1);
 
-        address treasury = abi.decode(data[0], (address));
-        string memory name = abi.decode(data[1], (string));
-        string memory symbol = abi.decode(data[2], (string));
-        address[] memory hodlers = abi.decode(data[3], (address[]));
-        uint256[] memory allocations = abi.decode(data[4], (uint256[]));
-        uint256 totalSupply = abi.decode(data[5], (uint256));
+        string memory name = abi.decode(data[0], (string));
+        string memory symbol = abi.decode(data[1], (string));
+        address[] memory hodlers = abi.decode(data[2], (address[]));
+        uint256[] memory allocations = abi.decode(data[3], (uint256[]));
 
         createdContracts[0] = address(
             new VotesTokenWithSupply(
                 name,
                 symbol,
                 hodlers,
-                allocations,
-                totalSupply,
-                treasury
+                allocations
             )
         );
 

--- a/contracts/VotesTokenWithSupply.sol
+++ b/contracts/VotesTokenWithSupply.sol
@@ -14,25 +14,17 @@ contract VotesTokenWithSupply is VotesToken {
     * @param symbol Token Symbol
     * @param hodlers Array of token receivers
     * @param allocations Allocations for each receiver
-    * @param totalSupply Token's total supply
-    * @param treasury Address to send difference between total supply and allocations
     */
     constructor(
         string memory name,
         string memory symbol,
         address[] memory hodlers,
-        uint256[] memory allocations,
-        uint256 totalSupply,
-        address treasury
+        uint256[] memory allocations
     ) VotesToken(name, symbol) {
         uint256 tokenSum;
         for (uint256 i = 0; i < hodlers.length; i++) {
             _mint(hodlers[i], allocations[i]);
             tokenSum += allocations[i];
-        }
-
-        if (totalSupply > tokenSum) {
-            _mint(treasury, totalSupply - tokenSum);
         }
     }
 }

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -30,20 +30,22 @@ describe("Token Factory", function () {
 
       const abiCoder = new ethers.utils.AbiCoder();
       const data = [
-        abiCoder.encode(["address"], [dao.address]),
         abiCoder.encode(["string"], ["DECENT"]),
         abiCoder.encode(["string"], ["DCNT"]),
-        abiCoder.encode(["address[]"], [[userA.address, userB.address]]),
+        abiCoder.encode(
+          ["address[]"],
+          [[dao.address, userA.address, userB.address]]
+        ),
         abiCoder.encode(
           ["uint256[]"],
           [
             [
+              ethers.utils.parseUnits("800", 18),
               ethers.utils.parseUnits("100", 18),
               ethers.utils.parseUnits("100", 18),
             ],
           ]
         ),
-        abiCoder.encode(["uint256"], [ethers.utils.parseUnits("1000", 18)]),
       ];
 
       const result = await tokenFactory.callStatic.create(data);
@@ -79,20 +81,22 @@ describe("Token Factory", function () {
     it("Token Factory does not deploy with incorrect data", async () => {
       const abiCoder = new ethers.utils.AbiCoder();
       const data = [
-        abiCoder.encode(["address"], [dao.address]),
         abiCoder.encode(["address"], [userA.address]),
         abiCoder.encode(["string"], ["DCNT"]),
-        abiCoder.encode(["address[]"], [[userA.address, userB.address]]),
+        abiCoder.encode(
+          ["address[]"],
+          [[dao.address, userA.address, userB.address]]
+        ),
         abiCoder.encode(
           ["uint256[]"],
           [
             [
+              ethers.utils.parseUnits("800", 18),
               ethers.utils.parseUnits("100", 18),
               ethers.utils.parseUnits("100", 18),
             ],
           ]
         ),
-        abiCoder.encode(["uint256"], [ethers.utils.parseUnits("1000", 18)]),
       ];
 
       // const result = await tokenFactory.callStatic.create(data);


### PR DESCRIPTION
This PR removes the treasury address and total token supply as parameters from the VotesTokenWithSupply. Going forward, the treasury address and token allocation should just be included in the existing hodlers and allocations arrays.