### PR TITLE
Refactor salt

### DIFF
--- a/contracts/TokenFactory.sol
+++ b/contracts/TokenFactory.sol
@@ -8,9 +8,10 @@ import "@openzeppelin/contracts/utils/Create2.sol";
 /// @notice Token Factory used to deploy votes tokens
 contract TokenFactory is ITokenFactory, ERC165 {
     /// @dev Creates an ERC-20 votes token
+    /// @param creator The address creating the module
     /// @param data The array of bytes used to create the token
     /// @return address The address of the created token
-    function create(bytes[] calldata data)
+    function create(address creator, bytes[] calldata data)
         external
         override
         returns (address[] memory)
@@ -25,7 +26,7 @@ contract TokenFactory is ITokenFactory, ERC165 {
 
         createdContracts[0] = Create2.deploy(
             0,
-            keccak256(abi.encodePacked(tx.origin, block.chainid, salt)),
+            keccak256(abi.encodePacked(creator, msg.sender, block.chainid, salt)),
             abi.encodePacked(
                 type(VotesTokenWithSupply).creationCode,
                 abi.encode(name, symbol, hodlers, allocations)

--- a/contracts/interfaces/ITokenFactory.sol
+++ b/contracts/interfaces/ITokenFactory.sol
@@ -5,7 +5,8 @@ interface ITokenFactory {
     event TokenCreated(address indexed tokenAddress);
 
     /// @dev Creates a module
+    /// @param creator The address creating the module
     /// @param data The array of bytes used to create the module
     /// @return address[] Array of the created module addresses
-    function create(bytes[] calldata data) external returns (address[] memory);
+    function create(address creator, bytes[] calldata data) external returns (address[] memory);
 }

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -51,8 +51,11 @@ describe("Token Factory", function () {
         abiCoder.encode(["bytes32"], [ethers.utils.formatBytes32String("hi")]),
       ];
 
-      const result = await tokenFactory.callStatic.create(data);
-      tx = await tokenFactory.create(data);
+      const result = await tokenFactory.callStatic.create(
+        deployer.address,
+        data
+      );
+      tx = await tokenFactory.create(deployer.address, data);
       // eslint-disable-next-line camelcase
       token = VotesTokenWithSupply__factory.connect(result[0], deployer);
     });
@@ -73,8 +76,13 @@ describe("Token Factory", function () {
       const predictedToken = ethers.utils.getCreate2Address(
         tokenFactory.address,
         ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes32"],
-          [deployer.address, chainId, ethers.utils.formatBytes32String("hi")]
+          ["address", "address", "uint256", "bytes32"],
+          [
+            deployer.address,
+            deployer.address,
+            chainId,
+            ethers.utils.formatBytes32String("hi"),
+          ]
         ),
         ethers.utils.solidityKeccak256(
           ["bytes", "bytes"],
@@ -141,7 +149,8 @@ describe("Token Factory", function () {
       ];
 
       // const result = await tokenFactory.callStatic.create(data);
-      await expect(tokenFactory.callStatic.create(data)).to.be.reverted;
+      await expect(tokenFactory.callStatic.create(deployer.address, data)).to.be
+        .reverted;
     });
 
     it("Supports the expected ERC165 interface", async () => {


### PR DESCRIPTION
This PR updates the factory contract to use creator and msg.sender for salt instead of tx.origin